### PR TITLE
Fix errors in Julia example

### DIFF
--- a/julia/reco.jl
+++ b/julia/reco.jl
@@ -1,7 +1,18 @@
 using Pkg
+using UUIDs
+
 # Install required packages
-for P in ["HDF5", "FFTW", "HTTP", "PyPlot"]
-  !haskey(Pkg.installed(), P) && Pkg.add(P)
+
+# Due to the removal of Pkg.installed() (https://discourse.julialang.org/t/how-to-use-pkg-dependencies-instead-of-pkg-installed/36416/7), we need to know the UUIDs of the packages.
+packageUUIDs = Dict{String, UUID}(
+"HDF5" => UUID("f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"),
+"FFTW" => UUID("7a1cc6ca-52ef-59f5-83cd-3a7055c09341"),
+"HTTP" => UUID("cd3eb016-35fb-5094-929b-558a96fad6f3"),
+"PyPlot" => UUID("d330b81b-6aea-500a-939a-2ce795aea3ee"),
+)
+
+for P in keys(packageUUIDs)
+  !haskey(Pkg.dependencies(), packageUUIDs[P]) && Pkg.add(P)
 end
 
 using HDF5, PyPlot, HTTP, FFTW

--- a/julia/utils.jl
+++ b/julia/utils.jl
@@ -1,17 +1,22 @@
 # Utility functions since HDF5.jl does not support the complex datatypes out of the box
 
 function getComplexType(file, dataset)
-  T = HDF5.hdf5_to_julia_eltype(
-            HDF5Datatype(
+  T = HDF5.get_jl_type(
+            HDF5.Datatype(
               HDF5.h5t_get_member_type( datatype(file[dataset]).id, 0 )
           )
         )
     return Complex{T}
 end
 
+function readComplexArray(file::HDF5.File, dataset)
+  T = getComplexType(file, dataset)
+  A = copy(HDF5.readmmap(file[dataset],getComplexType(file,dataset)))
+  return A
+end
+
 function readComplexArray(filename::String, dataset)
   h5open(filename, "r") do file
-    T = getComplexType(file, dataset)
-    return copy(readmmap(file[dataset],Array{getComplexType(file,dataset)}))
+    readComplexArray(file, dataset)
   end
 end


### PR DESCRIPTION
The current Julia example has errors due to two deprecations:

1. Pkg.installed() has been depracated. Fixed in this PR by using Pkg.dependencies() as proposed in https://discourse.julialang.org/t/how-to-use-pkg-dependencies-instead-of-pkg-installed/36416.
2. HDF5.hdf5_to_julia_eltype has been removed. The fix was copied over from https://github.com/MagneticParticleImaging/MPIFiles.jl/blob/27fa4fe46e9b9b035edb85b155b346b182584aad/src/Utils.jl#L30.